### PR TITLE
Add extremely basic scaffolding for LLVM based IR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "ir"
-version = "0.1.0"
-authors = ["Samuel Roth <samuel.roth@vita.dev>"]
+version = "0.0.0"
+authors = ["Samuel Roth <samuel.roth@vita.dev>", "Matthew Plant <maplant95@gmail.com>"]
 edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -1,0 +1,26 @@
+//! LLVM Basic Block.
+
+use std::rc::Rc;
+use super::function::Function;
+use super::value::Value;
+use super::instruction::{Instruction, InstructionListNode};
+
+/// Basic Block. A [Value] that is composed of a list of instructions.
+// TODO: List the conditions for a basic block to be well formed in these
+// doc comments.
+pub struct BasicBlock {
+    parent: Rc<Function>,
+    instrs: InstructionListNode,
+}
+
+impl Value for BasicBlock {
+}
+
+/// Sentinel value for the end of a basic block instruction list.
+pub struct EndBasicBlock {}
+
+impl Value for EndBasicBlock {}
+impl Instruction for EndBasicBlock {}
+
+
+

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,0 +1,15 @@
+//! LLVM Function.
+
+use std::rc::Rc;
+use super::basic_block::BasicBlock;
+
+pub struct Function {
+    args: Vec<Argument>,
+    entry_block: Rc<BasicBlock>,
+}
+
+/// Argument to a function.
+pub struct Argument {
+    parent: Rc<Function>,
+    name: String,
+}

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -1,0 +1,19 @@
+//! LLVM Instruction class
+
+use std::rc::Rc;
+use super::basic_block::BasicBlock;
+use super::value::Value;
+
+/// The Instruction trait is similar to the [Any] trait.
+pub trait Instruction: Value {
+}
+
+/// Any instruction. Forms a circular linked-list.
+// TODO: Possibly reconsider this structure for storing
+// instructions. 
+pub struct InstructionListNode {
+    parent: Rc<BasicBlock>,
+    next: Rc<InstructionListNode>,
+    prev: Rc<InstructionListNode>,
+    instr: Box<dyn Instruction>,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,7 @@
+//! An Intermediate Representation based on LLVM for compiler construction.
+//!
+
+pub mod value;
+pub mod instruction;
+pub mod basic_block;
+pub mod function;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,0 +1,5 @@
+//! Value trait
+
+/// LLVM Value Representation.
+pub trait Value {
+}


### PR DESCRIPTION
This is an extremely basic scaffolding that can be used as a starting point.
None of these APIs or design choices are set in stone so I am reducing the version number to `0.0.0` to begin.
This scaffolding also has heaving uses of Rc. I think that's fine for now, but we may want to use Pins and stuff to improve the speed later on. 